### PR TITLE
use --import instead of --loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"typescript": "*"
 	},
 	"scripts": {
-		"test": "glob -c \"node --loader tsx --no-warnings --test\" \"./tests/**/*.test.ts\""
+		"test": "glob -c \"node --import tsx --no-warnings --test\" \"./tests/**/*.test.ts\""
 	},
 	"volta": {
 		"node": "20.0.0"


### PR DESCRIPTION
```bash
Error: tsx must be loaded with --import instead of --loader
The --loader flag was deprecated in Node v20.6.0 and v18.19.0
```